### PR TITLE
replace GA tags with GTM tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,25 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-DHTXLNDNPV"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-DHTXLNDNPV');
-    </script>  
-    <!-- VIZLAB DATA STREAM Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-QV1JK700W8"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-QV1JK700W8');
-  </script>
-  <!-- End gtag -->
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KPDP9KP');</script>
+    <!-- End Google Tag Manager -->
     <!-- Primary Meta Tags -->
       <title>
         <%= VUE_APP_TIER %>
@@ -44,7 +32,7 @@
       <meta property="twitter:description" content="">
       <meta property="twitter:image" content="https://labs.waterdata.usgs.gov/visualizations/thumbnails/water-cycle-thumbnail.png">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-<script type='application/ld+json'>
+    <script type='application/ld+json'>
       { "@context": "http://www.schema.org",
         "@type": "WebSite", "name": "The Water Cycle",
         "url": "https://labs.waterdata.usgs.gov/visualizations/water-cycle",
@@ -64,6 +52,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KPDP9KP"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>
       <strong>We're sorry but this application doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>


### PR DESCRIPTION
This PR replaces the two GA4 tags in `index.html` with the code chunks that insert the new GTM tag.

The GTM container has been configured to point to the existing GA4 account.

I previewed the local host address with Google Tag Manager Tag Assistant and the tag fired:
![image](https://github.com/DOI-USGS/water-cycle/assets/54007288/8660b028-70e1-4a61-8c0a-588ffe7b304e)

That 2nd UA tag is added by the USGS analytics [script](https://www2.usgs.gov/scripts/analytics/usgs-analytics.js). I can't tell where the first comes from - it's not visible in inspector and is not in our code.

In the GTM preview,  GA4 Config tag is only fired for 'Container Loaded', not the other events listed there, e.g., 'Scroll Depth', 'Window Loaded'. Does that seem right? I'm guessing that data only comes through in Google Analytics, through the linked GA4 measurement ID?

In Google Analytics 'View Realtime' I can see my local host connection:
![image](https://github.com/DOI-USGS/water-cycle/assets/54007288/03fcfacf-195b-4757-9095-e21157656bd7)
