### PR TITLE
Add new pre-footer code and portfolio links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Here we track upcoming changes.
  
 ### Added
-- Added a change log
  
 ### Changed
  
 ### Fixed
+
+## [1.4.2] - 2026-03-01
+### Added
+- New pre-footer code links component 
  
 ## [1.4.1] - 2024-03-01
  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "water-cycle",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A zoomable water cycle diagram translated in multiple languages",
   "main": "index.html",
   "author": "USGS Vizlab",

--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -38,6 +38,7 @@
   --color-map-focal: var(--medium-orange);
   --color-map-default: var(--white);
   --color-USGS-header-footer: var(--usgs-blue);
+  --color-prefooter-highlight: var(--medium-blue);
 }
 
 *,

--- a/src/components/PreFooterCodeLinks.vue
+++ b/src/components/PreFooterCodeLinks.vue
@@ -42,11 +42,12 @@
   font-family: 'Noto Sans', sans-serif;
   font-size: 1.5rem;
   color: #1e1e1e;
+  width: 100%; // make full width to match page appearance
 
   &__divider {
     border-top: 1px solid #d4d8dd;
     margin: 0 auto 1.5rem;
-    width: min(90%, 700px);
+    width: 100%; // addded for full width
   }
 
   &__content {
@@ -56,6 +57,7 @@
     gap: 0.75rem;
     width: min(90%, 700px);
     margin: 0 auto;
+    width: 100%; // added for full width
   }
 
   &__item {

--- a/src/components/PreFooterCodeLinks.vue
+++ b/src/components/PreFooterCodeLinks.vue
@@ -1,33 +1,92 @@
 <template>
-  <div id="code-repository-link-container">
-    <a
-      :href="gitHubRepositoryLink"
-      target="_blank"
-      aria-label="github link"
-    >See the code behind this visualization
-      <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'github' }" />
-    </a>
+  <div class="pre-footer-links">
+    <div class="pre-footer-links__divider" />
+    <div class="pre-footer-links__content">
+      <a
+        class="pre-footer-links__item"
+        href="https://water.usgs.gov/vizlab/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        See more <span v-if="!mobileView">visualizations</span> from the USGS Vizlab
+      </a>
+      <a
+        class="pre-footer-links__item"
+        :href="gitHubRepositoryLink"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Get the code behind this page
+        <font-awesome-icon
+          :icon="{ prefix: 'fab', iconName: 'github' }"
+          aria-hidden="true"
+        />
+      </a>
+    </div>
   </div>
 </template>
 
 <script setup>
+  import { isMobileOnly } from 'mobile-device-detect';
+
+  // global variables
+  const mobileView = isMobileOnly;
+
   const gitHubRepositoryLink = import.meta.env.VITE_APP_GITHUB_REPOSITORY_LINK;
 </script>
 
 <style scoped lang="scss">
+.pre-footer-links {
+  background-color: white;
+  padding: 1.5rem 1rem 2rem;
+  font-family: 'Noto Sans', sans-serif;
+  font-size: 1.5rem;
+  color: #1e1e1e;
 
-  #code-repository-link-container {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-    background-color: var(--color-code-links-background);
-    margin: 0 auto;
-    padding: 0.4rem 1.5rem;
-    a {
-      color: var(--color-text);
-      margin-left: 10px;
-      text-decoration: none;
-    }
+  &__divider {
+    border-top: 1px solid #d4d8dd;
+    margin: 0 auto 1.5rem;
+    width: min(90%, 700px);
   }
 
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    width: min(90%, 700px);
+    margin: 0 auto;
+  }
+
+  &__item {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background-image: linear-gradient(var(--color-prefooter-highlight), var(--color-prefooter-highlight));
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 0.2rem;
+    padding-bottom: 0.1rem;
+    transition: color 0.2s ease-in-out;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--color-prefooter-highlight);
+    }
+  }
+}
+
+@media (min-width: 640px) {
+  .pre-footer-links {
+    &__content {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+}
 </style>


### PR DESCRIPTION
This implements the new pre-footer code and portfolio link component. Changes made:
- new component added `PreFooterCodeLinks.vue`
- CSS in `PreFooterCodeLinks.vue` modified to use `width: 100%` for the `.pre-footer-links`, `&__divider`, and `&__content` elements so the footer extends the full width of the page. 
- Added `--color-prefooter-highlight: var(--medium-blue);` to `base.css` to style active links

Note: We should adjust the width of this footer to look consistent with a given page width. I did it here since the diagram is full width, but on other pages we should keep the contstrained width to look clean with page design.

To review, pull down changes, Run `npm i` to install dependencies. Then run `npm run dev` to build locally. Expected output:

<img width="1380" height="337" alt="image" src="https://github.com/user-attachments/assets/c8387705-9632-4cd9-b7aa-abd4c9133e16" />
